### PR TITLE
[CPP-101] Footer Override

### DIFF
--- a/src/components/BocksRenderer.tsx
+++ b/src/components/BocksRenderer.tsx
@@ -7,6 +7,7 @@ import { Form } from './Form';
 import { HowTo } from './HowTo';
 import { Hero } from './Hero';
 import Accordion from './Accordion';
+import { Footer } from './Footer';
 
 // This object is used to map component names to React components
 const componentsMap: {
@@ -17,7 +18,7 @@ const componentsMap: {
 	Editorial,
 	Feature,
 	Form,
-	Footer: Pagopa.Footer,
+	Footer,
 	Header: Pagopa.Header,
 	Hero,
 	HowTo,
@@ -32,7 +33,7 @@ const Block = ({
 	const Component = componentsMap[block.type];
 	return !!Component ? (
 		<div id={block.slug} key={block.slug}>
-			<Component { ...block }  />
+			<Component {...block} />
 		</div>
 	) : null;
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,27 @@
+import Pagopa from '@pagopa/pagopa-editorial-components/';
+import {
+	CompanyLinkType,
+	PreLoginFooterLinksType,
+} from '@pagopa/pagopa-editorial-components/dist/components/Footer';
+import { LangSwitchProps } from '@pagopa/pagopa-editorial-components/dist/components/Footer/LangSwitch';
+import React from 'react';
+import { Html } from './Html';
+
+type FooterProps = LangSwitchProps & {
+	companyLink: CompanyLinkType;
+	legalInfo: JSX.Element | JSX.Element[];
+	links: PreLoginFooterLinksType;
+	onExit?: (exitAction: () => void) => void;
+	productsJsonUrl?: string;
+	onProductsJsonFetchError?: (reason: any) => void;
+	hideProductsColumn?: boolean;
+};
+
+export const Footer = ({ legalInfo, ...props }: FooterProps) => (
+	<Pagopa.Footer
+		{...props}
+		legalInfo={
+			typeof legalInfo === 'string' ? <Html data={legalInfo} /> : legalInfo
+		}
+	/>
+);


### PR DESCRIPTION
## Description
Adds a local Footer components overriding the one provided by editorial-components. The only overridden props is the companyLegalInfo so to use html for its content.

Fixes # [cpp-101](https://pagopa.atlassian.net/jira/software/projects/CPP/boards/278?selectedIssue=CPP-101)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Visual testing